### PR TITLE
PN-2724 Add results output to run-wait step

### DIFF
--- a/steps/run-wait/README.md
+++ b/steps/run-wait/README.md
@@ -1,3 +1,3 @@
 # run-wait
 
-This step waits for a Puppet run to complete.
+This step waits for a Puppet run to complete. It provides task or plan run results as its output.

--- a/steps/run-wait/outputs.schema.json
+++ b/steps/run-wait/outputs.schema.json
@@ -9,6 +9,10 @@
     "outcome": {
       "type": "string",
       "description": "The outcome of the Puppet run as provided by the Puppet agent"
+    },
+    "results": {
+      "type": "string",
+      "description": "The results of the Puppet task or plan run as provided by the Puppet agent"
     }
   }
 }

--- a/steps/run-wait/step.py
+++ b/steps/run-wait/step.py
@@ -35,6 +35,9 @@ while True:
     if run['state'].get('outcome'):
         relay.outputs.set('outcome', run['state']['outcome'])
 
+    if run['state'].get('run_results'):
+        relay.outputs.set('results', run['state']['run_results'])
+
     logging.info('Run complete with outcome {}'.format(run['state'].get('outcome', '(unknown)')))
 
     break


### PR DESCRIPTION
This step now has a new output called `results`, providing the results of a task or plan run from the Relay agent.